### PR TITLE
ci: circleci: Drop Fedora build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,16 +84,6 @@ jobs:
        - checkout
        - run: ci/circleci-build-flatpak.sh
        - run: ci/circleci-upload.sh
-   build-fedora:
-     docker:
-         - image: fedora:29
-     environment:
-       - OCPN_TARGET:  fedora
-     steps:
-       - run: su -c "dnf install -q -y git openssh-clients openssh-server"
-       - checkout
-       - run: ci/circleci-build-fedora.sh
-       - run: ci/circleci-upload.sh
    build-mingw:
      docker:
          - image: fedora:29
@@ -138,10 +128,6 @@ workflows:
             branches:
               only: master
       - build-flatpak:
-          filters:
-            branches:
-              only: master
-      - build-fedora:
           filters:
             branches:
               only: master


### PR DESCRIPTION
We cannot really keep up with the Fedora release schedule twice
a year. The current version is already outdated. For Fedora, focus
on flatpak and drop the native plugins.

See: https://github.com/OpenCPN/plugins/issues/28